### PR TITLE
filter icons improvements

### DIFF
--- a/client/src/Pages/Search.elm
+++ b/client/src/Pages/Search.elm
@@ -183,9 +183,16 @@ view shared model =
                             [ Html.map FromClansFilter <| Lazy.lazy FS.viewClans model.clansFilters
                             ]
                       , div [ class "filter-group__flags" ]
+                            [ Html.map FromClansFilter <| Lazy.lazy FS.viewCells model.clansFilters
+                            ]
+                      , div [ class "filter-group__flags" ]
                             [ Html.map FromDisciplinesFilter <| Lazy.lazy FS.viewDisciplines model.disciplineFilters
                             ]
+                      , div [ class "filter-group__flags" ]
+                            [ Html.map FromDisciplinesFilter <| Lazy.lazy FS.viewEdges model.disciplineFilters
+                            ]
                       ]
+
                     ]
                 )
             , div [ class "filter-group" ]

--- a/client/src/Pages/Search.sass
+++ b/client/src/Pages/Search.sass
@@ -13,8 +13,6 @@
   overflow: hidden
   margin-top: $space-medium
   gap: $space-micro
-  &__flags
-    flex: 0 0 max-content
 
 .searchresults
   margin-top: $space-medium

--- a/client/src/UI/DeckbuildSelections.elm
+++ b/client/src/UI/DeckbuildSelections.elm
@@ -274,6 +274,7 @@ viewMainFilters data =
     [ Html.map (Internal << FromStacksFilter) <| Lazy.lazy FS.viewPlayerStacks data.stackFilters
     , Html.map (Internal << FromPrimaryFilter) <| Lazy.lazy FS.viewPrimaryTraits data.primaryFilters
     , Html.map (Internal << FromClansFilter) <| Lazy.lazy FS.viewClans data.clansFilters
+    , Html.map (Internal << FromClansFilter) <| Lazy.lazy FS.viewCells data.clansFilters
     ]
 
 
@@ -282,6 +283,7 @@ viewSecondaryFilters data =
     [ Html.map (Internal << FromSecondaryFilter) <| Lazy.lazy FS.viewSecondaryTraits data.secondaryFilters
     , Html.map (Internal << FromAttackTypesFilter) <| Lazy.lazy FS.viewAttackTypes data.attackTypeFilters
     , Html.map (Internal << FromDisciplinesFilter) <| Lazy.lazy FS.viewDisciplines data.disciplineFilters
+    , Html.map (Internal << FromDisciplinesFilter) <| Lazy.lazy FS.viewEdges data.disciplineFilters
     , div [ class "deckbuild-filters__multi" ]
         [ label [ class "deckbuild-filters__multi-label", for "bp-multi" ]
             [ text "Blood Potency"

--- a/client/src/UI/FilterSelection.elm
+++ b/client/src/UI/FilterSelection.elm
@@ -33,9 +33,11 @@ module UI.FilterSelection exposing
     , update
     , viewAllStacks
     , viewAttackTypes
+    , viewCells
     , viewCities
     , viewClans
     , viewDisciplines
+    , viewEdges
     , viewPlayerStacks
     , viewPrimaryTraits
     , viewSecondaryTraits
@@ -462,10 +464,8 @@ viewClans flags =
         [ viewFlag (IconV2.clan IconV2.Standard Cl.BanuHaqim) (\old -> { old | banuHaqim = not old.banuHaqim }) flags.banuHaqim
         , viewFlag (IconV2.clan IconV2.Standard Cl.Brujah) (\old -> { old | brujah = not old.brujah }) flags.brujah
         , viewFlag (IconV2.clan IconV2.Standard Cl.Caitiff) (\old -> { old | caitiff = not old.caitiff }) flags.caitiff
-        , viewFlag (IconV2.clan IconV2.Standard Cl.Faithful) (\old -> { old | faithful = not old.faithful }) flags.faithful
         , viewFlag (IconV2.clan IconV2.Standard Cl.Gangrel) (\old -> { old | gangrel = not old.gangrel }) flags.gangrel
         , viewFlag (IconV2.clan IconV2.Standard Cl.Hecata) (\old -> { old | hecata = not old.hecata }) flags.hecata
-        , viewFlag (IconV2.clan IconV2.Standard Cl.Inquisitive) (\old -> { old | inquisitive = not old.inquisitive }) flags.inquisitive
         , viewFlag (IconV2.clan IconV2.Standard Cl.Lasombra) (\old -> { old | lasombra = not old.lasombra }) flags.lasombra
         , viewFlag (IconV2.clan IconV2.Standard Cl.Malkavian) (\old -> { old | malkavian = not old.malkavian }) flags.malkavian
         , viewFlag (IconV2.clan IconV2.Standard Cl.Ministry) (\old -> { old | ministry = not old.ministry }) flags.ministry
@@ -477,6 +477,13 @@ viewClans flags =
         , viewFlag (IconV2.clan IconV2.Standard Cl.Tremere) (\old -> { old | tremere = not old.tremere }) flags.tremere
         , viewFlag (IconV2.clan IconV2.Standard Cl.Tzimisce) (\old -> { old | tzimisce = not old.tzimisce }) flags.tzimisce
         , viewFlag (IconV2.clan IconV2.Standard Cl.Ventrue) (\old -> { old | ventrue = not old.ventrue }) flags.ventrue
+        ]
+
+viewCells : Clans -> Html (Msg Clans)
+viewCells flags =
+    div [ class "filterpicker" ]
+        [ viewFlag (IconV2.clan IconV2.Standard Cl.Faithful) (\old -> { old | faithful = not old.faithful }) flags.faithful
+        , viewFlag (IconV2.clan IconV2.Standard Cl.Inquisitive) (\old -> { old | inquisitive = not old.inquisitive }) flags.inquisitive
         ]
 
 
@@ -584,24 +591,28 @@ viewDisciplines flags =
     div [ class "filterpicker" ]
         [ viewFlag (IconV2.discipline IconV2.Standard Dis.Animalism) (\old -> { old | animalism = not old.animalism }) flags.animalism
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Auspex) (\old -> { old | auspex = not old.auspex }) flags.auspex
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.BeastWhisperer) (\old -> { old | beastWhisperer = not old.beastWhisperer }) flags.beastWhisperer
         , viewFlag (IconV2.discipline IconV2.Standard Dis.BloodSorcery) (\old -> { old | bloodSorcery = not old.bloodSorcery }) flags.bloodSorcery
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Celerity) (\old -> { old | celerity = not old.celerity }) flags.celerity
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Dominate) (\old -> { old | dominate = not old.dominate }) flags.dominate
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Fortitude) (\old -> { old | fortitude = not old.fortitude }) flags.fortitude
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.Global) (\old -> { old | global = not old.global }) flags.global
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.Library) (\old -> { old | library = not old.library }) flags.library
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Obfuscate) (\old -> { old | obfuscate = not old.obfuscate }) flags.obfuscate
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Oblivion) (\old -> { old | oblivion = not old.oblivion }) flags.oblivion
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Potence) (\old -> { old | potence = not old.potence }) flags.potence
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Presence) (\old -> { old | presence = not old.presence }) flags.presence
         , viewFlag (IconV2.discipline IconV2.Standard Dis.Protean) (\old -> { old | protean = not old.protean }) flags.protean
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.RepelTheUnnatural) (\old -> { old | repelTheUnnatural = not old.repelTheUnnatural }) flags.repelTheUnnatural
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.SenseTheUnnatural) (\old -> { old | senseTheUnnatural = not old.senseTheUnnatural }) flags.senseTheUnnatural
-        , viewFlag (IconV2.discipline IconV2.Standard Dis.ThwartTheUnnatural) (\old -> { old | thwartTheUnnatural = not old.thwartTheUnnatural }) flags.thwartTheUnnatural
         , viewFlag (IconV2.discipline IconV2.Standard Dis.ThinBloodAlchemy) (\old -> { old | thinBloodAlchemy = not old.thinBloodAlchemy }) flags.thinBloodAlchemy
         ]
 
+viewEdges : Disciplines -> Html (Msg Disciplines)
+viewEdges flags =
+    div [ class "filterpicker" ]
+        [ viewFlag (IconV2.discipline IconV2.Standard Dis.BeastWhisperer) (\old -> { old | beastWhisperer = not old.beastWhisperer }) flags.beastWhisperer
+        , viewFlag (IconV2.discipline IconV2.Standard Dis.Global) (\old -> { old | global = not old.global }) flags.global
+        , viewFlag (IconV2.discipline IconV2.Standard Dis.Library) (\old -> { old | library = not old.library }) flags.library
+        , viewFlag (IconV2.discipline IconV2.Standard Dis.RepelTheUnnatural) (\old -> { old | repelTheUnnatural = not old.repelTheUnnatural }) flags.repelTheUnnatural
+        , viewFlag (IconV2.discipline IconV2.Standard Dis.SenseTheUnnatural) (\old -> { old | senseTheUnnatural = not old.senseTheUnnatural }) flags.senseTheUnnatural
+        , viewFlag (IconV2.discipline IconV2.Standard Dis.ThwartTheUnnatural) (\old -> { old | thwartTheUnnatural = not old.thwartTheUnnatural }) flags.thwartTheUnnatural
+        ]
 
 disciplineIsAllowedWide : Disciplines -> C.Card -> Bool
 disciplineIsAllowedWide flags card =


### PR DESCRIPTION
this is a two-fer:

- it groups the filter buttons for Cells and Edges separately from Clans and Disciplines. see RDB-61

![a](https://github.com/RivalsDB/rivalsdb/assets/1410427/9b366b6b-efdb-4ec5-a0b7-ff6f6d74ccc2)

![b](https://github.com/RivalsDB/rivalsdb/assets/1410427/45ca5e68-7ec6-4ac5-81fb-6f5816b62e61)


- it stops filter icons from being cut off on mobile devices. see RDB-31

![mobile](https://github.com/RivalsDB/rivalsdb/assets/1410427/4bd210d8-3581-4fd8-8c8d-137bc8f966b7)


