### PR TITLE
removes reference to deleted cards temp directory from build process.

### DIFF
--- a/server/src/server/server.ts
+++ b/server/src/server/server.ts
@@ -31,15 +31,6 @@ const cardImagesFolder = path.join(
   "assets",
   "card"
 );
-const tempCardImagesFolder = path.join(
-  dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "assets",
-  "card-temp"
-);
 const logoFolder = path.join(dirname, "..", "..", "..", "..", "assets", "logo");
 
 const clientDistFolder = path.join(
@@ -79,15 +70,6 @@ export async function createServer(): Promise<Service> {
     prefix: "/card",
     decorateReply: false,
     maxAge: "14d",
-    lastModified: false,
-  });
-  fastify.register(fastifyStatic, {
-    root: tempCardImagesFolder,
-    wildcard: false,
-    preCompressed: false,
-    prefix: "/card",
-    decorateReply: false,
-    maxAge: "2d",
     lastModified: false,
   });
   fastify.register(fastifyStatic, {


### PR DESCRIPTION
the card-temp directory was removed from the code base a while back, causing this step in the build pipeline to fail and emit an error message.
removing the step altogether fixes this issue.