### PR TITLE
adds missing city deck filter for Rio.

### DIFF
--- a/client/src/UI/FilterSelection.elm
+++ b/client/src/UI/FilterSelection.elm
@@ -722,6 +722,7 @@ viewCities flags =
         [ viewFlag (Icon.icon ( Icon.CityCore, Icon.Standard )) (\old -> { old | core = not old.core }) flags.core
         , viewFlag (Icon.icon ( Icon.CityHoE, Icon.Standard )) (\old -> { old | heartOfEurope = not old.heartOfEurope }) flags.heartOfEurope
         , viewFlag (Icon.icon ( Icon.CityConclave, Icon.Standard )) (\old -> { old | conclave22 = not old.conclave22 }) flags.conclave22
+        , viewFlag (Icon.icon ( Icon.CityHaH, Icon.Standard )) (\old -> { old | rio = not old.rio }) flags.rio
         ]
 
 
@@ -739,6 +740,9 @@ cityIsAllowedWide flags card =
 
                     Pack.HeartOfEurope ->
                         flags.heartOfEurope
+
+                    Pack.HuntersAndHunted ->
+                        flags.rio
 
                     _ ->
                         flags.core

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "engines": {
     "node": "18.x",
-    "yarn": "1.22.19"
+    "yarn": "1.22.x"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
![image](https://github.com/RivalsDB/rivalsdb/assets/1410427/31a813c1-090c-4d05-8959-87500d5c1edc)

see RDB-67