### PR TITLE
show agenda, leader, and haven on mouse-over on smaller screens

### DIFF
--- a/client/src/UI/Decklist.elm
+++ b/client/src/UI/Decklist.elm
@@ -154,7 +154,14 @@ viewAgenda agenda =
         ]
         [ p [ class "decklist__core-heading" ]
             [ text "Agenda: "
-            , text <| Maybe.withDefault "Unknown" <| Maybe.map .name agenda
+            , span [ class "card-name" ]
+                [ span [ class "card-name__name" ] [ text <| Maybe.withDefault "Unknown" <| Maybe.map .name agenda ]
+                , span [ class "card-name__image" ]
+                    [ agenda
+                        |> Maybe.map (Cards.AgendaCard >> UI.Card.eager)
+                        |> Maybe.withDefault (text "")
+                    ]
+                ]
             ]
         , div [ class "decklist__core-image" ]
             [ agenda
@@ -172,7 +179,14 @@ viewLeader leader =
         ]
         [ p [ class "decklist__core-heading" ]
             [ text "Leader: "
-            , text <| Maybe.withDefault "Unknown" <| Maybe.map .name leader
+            , span [ class "card-name" ]
+                [ span [ class "card-name__name" ] [ text <| Maybe.withDefault "Unknown" <| Maybe.map .name leader ]
+                , span [ class "card-name__image" ]
+                    [ leader
+                        |> Maybe.map (Cards.FactionCard >> UI.Card.eager)
+                        |> Maybe.withDefault (text "")
+                    ]
+                ]
             ]
         , div [ class "decklist__core-image" ]
             [ leader
@@ -190,7 +204,14 @@ viewHaven haven =
         ]
         [ p [ class "decklist__core-heading" ]
             [ text "Haven: "
-            , text <| Maybe.withDefault "Unknown" <| Maybe.map .name haven
+            , span [ class "card-name" ]
+                [ span [ class "card-name__name" ] [ text <| Maybe.withDefault "Unknown" <| Maybe.map .name haven ]
+                , span [ class "card-name__image" ]
+                    [ haven
+                        |> Maybe.map (Cards.HavenCard >> UI.Card.eager)
+                        |> Maybe.withDefault (text "")
+                    ]
+                ]
             ]
         , div [ class "decklist__core-image" ]
             [ haven


### PR DESCRIPTION
small screen deckviewer hover effect examples:

![2024-03-26_18-05_1](https://github.com/RivalsDB/rivalsdb/assets/1410427/ded22c64-333d-4a86-ba00-c2242eae94df)
![2024-03-26_18-06](https://github.com/RivalsDB/rivalsdb/assets/1410427/c234deb7-d225-4d19-8f13-d7b279e2af4d)
![2024-03-26_18-05](https://github.com/RivalsDB/rivalsdb/assets/1410427/b72adcc3-d8e3-4544-8af4-035f87e14c95)


works as before for undefined agenda, leader, or haven in the deck-builder, bigger screens as well:

![2024-03-26_18-31](https://github.com/RivalsDB/rivalsdb/assets/1410427/3558ae76-16b1-4c51-a3e9-514e87ab179c)
![2024-03-26_18-35](https://github.com/RivalsDB/rivalsdb/assets/1410427/ee7c530d-349c-4828-a6c7-19bd9cdeedfc)


example of hover-effect on small screen deckbuilder 

![image](https://github.com/RivalsDB/rivalsdb/assets/1410427/daf0a18b-a5b0-4165-9f1f-02fef0165798)

